### PR TITLE
[win] Open RustDedicated in an own command prompt instead of new windows terminal

### DIFF
--- a/win/run.bat
+++ b/win/run.bat
@@ -48,7 +48,7 @@ steamcmd.exe +login anonymous ^
 
 rem Start up the server
 cd %server%
-RustDedicated.exe -nographics -batchmode -logs -silent-crashes ^
+start "RustDedicated" /B RustDedicated.exe -nographics -batchmode -logs -silent-crashes ^
                   -server.hostname "%name%" ^
                   -server.identity "%identity%" ^
                   -server.port %port% ^


### PR DESCRIPTION
New windows terminal is not working properly with RustDedicated on Windows 11.

## Before:

![Skärmbild_20230221_100515](https://user-images.githubusercontent.com/28024000/220299953-e188a522-8cd7-4641-b05e-27d0f990b408.png)

## After:
![Skärmbild_20230221_100829](https://user-images.githubusercontent.com/28024000/220300177-38477fdf-7bae-42d2-8a5e-2998a7c6ff4e.png)
