### PR TITLE
[linux] Enhance install script to support Arch package managers

### DIFF
--- a/linux/install.sh
+++ b/linux/install.sh
@@ -10,10 +10,10 @@ CARBON_DL=https://github.com/CarbonCommunity/Carbon.Core/releases/download/previ
 BASE="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 RUST_HOME="${BASE}/server"
 
-# Install steamcmd and some generic dependencies
-sudo -- bash <<EOF
-	set -e
-
+# Detect package manager
+if command -v apt-get &> /dev/null; then
+    # Ubuntu/Debian packages
+    sudo -- bash <<EOF
 	apt-get -qq --yes --no-install-recommends install software-properties-common
 	apt-add-repository non-free && dpkg --add-architecture i386
 	apt-get -qq update
@@ -22,6 +22,32 @@ sudo -- bash <<EOF
 	DEBIAN_FRONTEND=noninteractive apt-get -qq --yes --no-install-recommends install \
 		steamcmd libsdl2-2.0-0 libgdiplus curl unzip
 EOF
+    elif command -v pacman &> /dev/null; then
+    # Arch Linux packages
+    bash <<EOF
+    sudo pacman -S --noconfirm sdl2 libgdiplus curl unzip
+
+    # Check and install AUR helper if steamcmd is not available
+    if ! command -v steamcmd &> /dev/null; then
+        if command -v paru &> /dev/null; then
+            paru -S --noconfirm steamcmd
+        elif command -v yay &> /dev/null; then
+            yay -S --noconfirm steamcmd
+        else
+            # Install paru if no AUR helper exists
+            git clone https://aur.archlinux.org/paru.git
+            cd paru
+            makepkg -si --noconfirm
+            cd ..
+            rm -rf paru
+            paru -S --noconfirm steamcmd
+        fi
+    fi
+EOF
+else
+    echo "Unsupported package manager. Please install dependencies manually."
+    exit 1
+fi
 
 # Download and install Carbon
 curl --fail --location --output /tmp/$(basename ${CARBON_DL}) ${CARBON_DL}
@@ -31,4 +57,12 @@ tar xf /tmp/$(basename ${CARBON_DL}) -C "${RUST_HOME}"
 rm /tmp/$(basename ${CARBON_DL})
 
 ${BASE}/update.sh
-${BASE}/run.sh
+
+# Prompt user about running the server
+read -p "Do you want to start the Rust Carbon server now? (y/n): " run_server
+
+if [[ "$run_server" =~ ^[Yy]$ ]]; then
+    ${BASE}/run.sh
+else
+    echo "Server not started. You can run it later using ${BASE}/run.sh"
+fi

--- a/linux/update.sh
+++ b/linux/update.sh
@@ -9,6 +9,6 @@ set -e
 BASE="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
 RUST_HOME="${BASE}/server"
 
-/usr/games/steamcmd +@sSteamCmdForcePlatformType linux +force_install_dir "${RUST_HOME}" \
+steamcmd +@sSteamCmdForcePlatformType linux +force_install_dir "${RUST_HOME}" \
 	+login anonymous +app_info_update 1 +app_update 258550 validate +quit
 	


### PR DESCRIPTION
This updates the install script to consider Arch distro as an option.

It does not modify the Ubuntu/Debian implementation as I have no experience with it.

It also checks for AUR helpers for Arch as steamcmd is not directly available (afaik).

* Also added a prompt to see if the user wants to run the server after setting it up